### PR TITLE
Cursor/add agentrouter provider and update frontend 0aeb

### DIFF
--- a/models.md
+++ b/models.md
@@ -37,6 +37,23 @@ All Pollination AI models are free to use:
 | gemini-2.5-pro-preview-05-06    | Gemini 2.5 Pro (Preview)             | Paid         |
 | gemini-2.5-flash-preview-05-20  | Gemini 2.5 Flash (Preview)           | **Free Tier**|
 
+### AgentRouter (Free Tier Available)
+> **🎉 Special Offer**: AgentRouter provides **$200 in free credits** to get you started! All models below are available with this generous free tier.
+
+| Model Name                          | Description                           | Notes        |
+|-------------------------------------|---------------------------------------|--------------|
+| gpt-5                              | OpenAI's most advanced model         | **Free**     |
+| claude-3-5-haiku-20241022          | Claude 3.5 Haiku                      | **Free**     |
+| claude-haiku-4-5-20251001          | Claude Haiku 4.5                      | **Free**     |
+| claude-sonnet-4-20250514           | Claude 4 Sonnet                       | **Free**     |
+| claude-sonnet-4-5-20250929         | Claude Sonnet 4.5                     | **Free**     |
+| deepseek-r1-0528                   | DeepSeek R1 reasoning model           | **Free**     |
+| deepseek-v3.1                      | DeepSeek v3.1                         | **Free**     |
+| deepseek-v3.2                      | DeepSeek v3.2                         | **Free**     |
+| glm-4.5                            | GLM-4.5 model                         | **Free**     |
+| glm-4.6                            | GLM-4.6 model                         | **Free**     |
+| grok-code-fast-1                   | Grok Code Fast 1                      | **Free**     |
+
 ### OpenRouter (Free Tier Available)
 | Model Name                          | Description                           | Notes        |
 |-------------------------------------|---------------------------------------|--------------|

--- a/website/docs/models.md
+++ b/website/docs/models.md
@@ -75,6 +75,23 @@ All Xibe AI Provider models are free to use with no API key required:
 | gemini-2.5-pro                  | Gemini 2.5 Pro                       | Paid         | ❌ |
 | gemini-2.5-flash                | Gemini 2.5 Flash                     | **Free Tier**| ✅ |
 
+### AgentRouter (Free Tier Available)
+> **🎉 Special Offer**: AgentRouter provides **$200 in free credits** to get you started! All models below are available with this generous free tier.
+
+| Model Name                          | Description                           | Notes        | Free Tier |
+|-------------------------------------|---------------------------------------|--------------|-----------|
+| gpt-5                              | OpenAI's most advanced model         | **Free**     | ✅ |
+| claude-3-5-haiku-20241022          | Claude 3.5 Haiku                      | **Free**     | ✅ |
+| claude-haiku-4-5-20251001          | Claude Haiku 4.5                      | **Free**     | ✅ |
+| claude-sonnet-4-20250514           | Claude 4 Sonnet                       | **Free**     | ✅ |
+| claude-sonnet-4-5-20250929         | Claude Sonnet 4.5                     | **Free**     | ✅ |
+| deepseek-r1-0528                   | DeepSeek R1 reasoning model           | **Free**     | ✅ |
+| deepseek-v3.1                      | DeepSeek v3.1                         | **Free**     | ✅ |
+| deepseek-v3.2                      | DeepSeek v3.2                         | **Free**     | ✅ |
+| glm-4.5                            | GLM-4.5 model                         | **Free**     | ✅ |
+| glm-4.6                            | GLM-4.6 model                         | **Free**     | ✅ |
+| grok-code-fast-1                   | Grok Code Fast 1                      | **Free**     | ✅ |
+
 ### OpenRouter (Free Tier Available)
 | Model Name                          | Description                           | Notes        | Free Tier |
 |-------------------------------------|---------------------------------------|--------------|-----------|

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -51,6 +51,31 @@ function HeroSection() {
           </div>
         </div>
 
+        {/* AgentRouter Support Notice */}
+        <div style={{
+          background: 'rgba(255, 0, 0, 0.1)',
+          border: '2px solid rgba(255, 0, 0, 0.4)',
+          borderRadius: '8px',
+          padding: '12px 16px',
+          marginBottom: '24px',
+          textAlign: 'center',
+          color: '#ff0000',
+          fontSize: '14px',
+          fontWeight: '600',
+          backdropFilter: 'blur(10px)',
+          maxWidth: '600px',
+          marginLeft: 'auto',
+          marginRight: 'auto',
+          boxShadow: '0 4px 15px rgba(255, 0, 0, 0.2)'
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '8px' }}>
+            <span>🚀</span>
+            <span>
+              <strong>NEW:</strong> agentrouter.org is now supported with $200 free credits!
+            </span>
+          </div>
+        </div>
+
         <div className={styles.heroContent}>
           <div className={styles.heroText}>
             <Heading ref={titleRef} as="h1" className={styles.heroTitle}>
@@ -59,7 +84,7 @@ function HeroSection() {
               <br />Development
             </Heading>
             <p ref={subtitleRef} className={styles.heroSubtitle}>
-              Xibe AI is a revolutionary AI development platform that combines 27+ AI models,
+              Xibe AI is a revolutionary AI development platform that combines 40+ AI models,
               intelligent code generation, and seamless workflow automation. Build faster,
               smarter, and more efficiently with the power of AI.
             </p>
@@ -91,7 +116,7 @@ function HeroSection() {
             
             <div ref={statsRef} className={styles.heroStats}>
               <div className={styles.stat}>
-                <span className={styles.statNumber}>27+</span>
+                <span className={styles.statNumber}>40+</span>
                 <span className={styles.statLabel}>AI Models</span>
               </div>
               <div className={styles.stat}>
@@ -158,8 +183,8 @@ function FeaturesSection() {
   const features = [
     {
       icon: '🤖',
-      title: '27+ AI Models',
-      description: 'Access Claude 3.5 Haiku, Gemini 2.5 Flash, GPT-4, and 25+ other AI models. Switch between models instantly for the best results.',
+      title: '40+ AI Models',
+      description: 'Access Claude 3.5 Haiku, Gemini 2.5 Flash, GPT-5, and 37+ other AI models. Switch between models instantly for the best results.',
       gradient: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)'
     },
     {
@@ -230,12 +255,12 @@ function ModelsSection() {
   const models = [
     { name: 'Claude 3.5 Haiku', type: 'Free', color: '#FF6B6B' },
     { name: 'Gemini 2.5 Flash', type: 'Free', color: '#4ECDC4' },
-    { name: 'GPT-4', type: 'Premium', color: '#45B7D1' },
-    { name: 'Claude 3.5 Sonnet', type: 'Premium', color: '#96CEB4' },
+    { name: 'GPT-5', type: 'Free', color: '#FF0000' },
+    { name: 'Claude 4 Sonnet', type: 'Free', color: '#96CEB4' },
     { name: 'DeepSeek R1', type: 'Free', color: '#FFEAA7' },
-    { name: 'GLM-4 9B', type: 'Free', color: '#DDA0DD' },
-    { name: 'Llama 3.2 1B', type: 'Free', color: '#98D8C8' },
-    { name: 'Mistral Small', type: 'Free', color: '#F7DC6F' }
+    { name: 'GLM-4.6', type: 'Free', color: '#DDA0DD' },
+    { name: 'Grok Code Fast', type: 'Free', color: '#98D8C8' },
+    { name: 'DeepSeek v3.2', type: 'Free', color: '#F7DC6F' }
   ];
 
 
@@ -244,7 +269,7 @@ function ModelsSection() {
       <div className="container">
         <div className={styles.sectionHeader}>
           <Heading as="h2" className={styles.sectionTitle}>
-            Powered by 27+ AI Models
+            Powered by 40+ AI Models
           </Heading>
           <p className={styles.sectionSubtitle}>
             Access the world's most advanced AI models for coding, design, and development
@@ -263,7 +288,7 @@ function ModelsSection() {
         </div>
         
         <div className={styles.modelsCTA}>
-          <p>And 19+ more models available...</p>
+          <p>And 32+ more models available...</p>
           <Link to="/docs" className={styles.modelsButton}>
             Start Building with AI
           </Link>
@@ -294,8 +319,8 @@ function VideoSection() {
       text: "Commit, branch, and review – all inside your AI workflow."
     },
     {
-      title: "27+ Models, Free",
-      text: "Claude 3.5 Haiku, Gemini 2.5 Flash, and many more at your fingertips."
+      title: "40+ Models, Free",
+      text: "Claude 3.5 Haiku, Gemini 2.5 Flash, GPT-5, and many more at your fingertips."
     }
   ];
 
@@ -368,7 +393,7 @@ function CTASection() {
             </Link>
           </div>
           <div className={styles.ctaFeatures}>
-            <span>✓ 27+ AI Models</span>
+            <span>✓ 40+ AI Models</span>
             <span>✓ Designer Mode (Beta)</span>
             <span>✓ Auto-Fix Problems</span>
             <span>✓ Native Git Support</span>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds AgentRouter as a provider with a $200 free credit offer and updates the site to show 40+ available models.

- **New Features**
  - Added AgentRouter to the models docs with a list of supported models (e.g., GPT-5, Claude 4 Sonnet, DeepSeek, GLM, Grok Code Fast) and free tier details.
  - Updated the homepage: new AgentRouter banner, model count raised from 27+ to 40+, refreshed featured model list and copy across hero, stats, models, video, and CTA sections.

<!-- End of auto-generated description by cubic. -->

